### PR TITLE
Updated requirements for docs to the latest

### DIFF
--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,4 +1,4 @@
-sphinx>=1.7.7,<2
-sphinx-autodoc-typehints>=1.3.0,<2
-sphinx-icontract>=1.0.0
-sphinx-rtd-theme>=0.4.1,<1
+sphinx>=3.2.1,<4
+sphinx-autodoc-typehints>=1.11.0,<2
+sphinx-icontract>=2.0.1,<3
+sphinx-rtd-theme>=0.5.0,<1


### PR DESCRIPTION
This update was necessary since the docs did not build on readthedocs
anymore.