### PR TITLE
Update spur to 0.3.22 and use close() method

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     license='License :: OSI Approved :: MIT License',
     keywords='ssh sftp spur paramiko execute remote commands modify files',
     packages=find_packages(exclude=['tests']),
-    install_requires=['spur==0.3.20', 'typing_extensions>=3.6.2.1', 'icontract>=2.0.1,<3', 'temppathlib>=1.0.3,<2'],
+    install_requires=['spur==0.3.22', 'typing_extensions>=3.6.2.1', 'icontract>=2.0.1,<3', 'temppathlib>=1.0.3,<2'],
     extras_require={
         'dev':
         ['mypy==0.790', 'pylint==2.6.0', 'yapf==0.20.2', 'tox>=3.0.0', 'coverage>=4.5.1,<5', 'pydocstyle>=2.1.1,<3']

--- a/spurplus/__init__.py
+++ b/spurplus/__init__.py
@@ -1047,11 +1047,12 @@ class SshShell(icontract.DBC):
 
     def close(self) -> None:
         """Close the underlying spur shell and SFTP (if ``close_spur_shell`` and ``close_sftp``, respectively)."""
-        if self.close_spur_shell:
-            self._spur.__exit__()
-
-        if self.close_sftp:
-            self._sftp.close()
+        try:
+            if self.close_spur_shell:
+                self._spur.close()
+        finally:
+            if self.close_sftp:
+                self._sftp.close()
 
     def __enter__(self) -> 'SshShell':
         """Enter the context and give the shell prepared in the constructor."""


### PR DESCRIPTION
I also put a try: finally: in the close() method to still close sftp if there would be an error when closing the spur connection.